### PR TITLE
Pin module versions into puppet_apply.sh

### DIFF
--- a/script/puppet_apply.sh
+++ b/script/puppet_apply.sh
@@ -13,9 +13,9 @@ PATH_TO_SCRIPT_FOR_CRON=${PATH_TO_SCRIPT_FOR_CRON:-/usr/local/bin/run_puppet.sh}
 PUPPET_LOGS=${PUPPET_LOGS:-/var/log/puppet.log}
 PATH_TO_MANIFESTS="$(cd "$(dirname "$(readlink -f "${BASH_SOURCE[@]}")")"; cd ../manifests; pwd)"
 MANIFEST_NAME=${MANIFEST_NAME:-team-network-lab.pp}
-MODULES_TO_INSTALL=${MODULES_TO_INSTALL:-"puppetlabs/postgresql \
-puppetlabs/vcsrepo thias-sysctl puppetlabs-firewall \
-garethr/docker camptocamp-kmod saz-locales"}
+MODULES_TO_INSTALL=${MODULES_TO_INSTALL:-"puppetlabs/concat:2.2.0 puppetlabs/apt:2.3.0 \
+puppetlabs/postgresql:4.9.0 puppetlabs/vcsrepo:1.5.0 thias-sysctl puppetlabs-firewall:1.8.2 \
+garethr/docker:5.3.0 camptocamp-kmod saz-locales"}
 
 
 function check-root {
@@ -100,7 +100,8 @@ function install-modules-and-run-puppet {
     apt update;
     apt "${APT_ARGS}" install "${PACKAGES_TO_INSTALL}";
     for module in ${MODULES_TO_INSTALL}; do
-      puppet module install "${module}"
+      modver=$(echo ${module} | perl -pe 's/(.+)(\:)((?(2)(.+)))/\1 --version=\3/g')
+      puppet module install ${modver}
     done
   fi
   puppet apply "${PUPPET_APPLY_ARGS[@]}" "${PATH_TO_MANIFESTS}"/"${MANIFEST_NAME}"


### PR DESCRIPTION
Without this pinning puppet use fresher stdlib, apt and concat modules.
Docker module can't work together with they.